### PR TITLE
Update to eslint-config-prettier@2.5.0

### DIFF
--- a/lib/prettier-standard.js
+++ b/lib/prettier-standard.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["./base.js", "prettier"]
+  extends: ["./base.js", "prettier", "prettier/standard"]
 }

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "author": "Nick Petruzzelli <code.npetruzzelli@gmail.com>",
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "eslint-config-prettier": "^2.3.0",
+    "eslint-config-prettier": "^2.5.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-prettier": "^2.1.2"
   },
   "devDependencies": {
     "eslint": "^4.1.1",
-    "eslint-config-prettier": "^2.3.0",
+    "eslint-config-prettier": "^2.5.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.1.0",


### PR DESCRIPTION
... which adds exclusions for eslint-plugin-standard.
See https://github.com/prettier/eslint-config-prettier/issues/29