### PR TITLE
Update Dependencies and Improve Installation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,8 @@ If you are making a custom configuration that absolutely must extend a different
     "prettier-standard/lib/base",
     "foo",
     "bar",
-    "prettier"
+    "prettier",
+    "prettier/standard"
   ]
 }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -4,6 +4,14 @@ An ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-co
 
 ## Installation
 
+### One Line Installation
+
+```
+npm install --save-dev eslint-config-prettier-standard eslint eslint-config-prettier eslint-config-standard eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-standard eslint-plugin-prettier prettier
+```
+
+###Line By Line Installation
+
 Install the peer dependencies:
 
 ```

--- a/lib/prettier-standard.js
+++ b/lib/prettier-standard.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["./base.js", "prettier"]
+  extends: ["./base.js", "prettier", "prettier/standard"]
 }

--- a/package.json
+++ b/package.json
@@ -22,20 +22,20 @@
   "author": "Nick Petruzzelli <code.npetruzzelli@gmail.com>",
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "eslint-config-prettier": "^2.3.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-prettier": "^2.1.2"
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-prettier": "^2.6.0"
   },
   "devDependencies": {
-    "eslint": "^4.1.1",
-    "eslint-config-prettier": "^2.3.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-node": "^5.1.0",
-    "eslint-plugin-prettier": "^2.1.2",
-    "eslint-plugin-promise": "^3.5.0",
+    "eslint": "^4.19.1",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.11.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-standard": "^3.0.1",
     "lodash.merge": "^4.6.0",
-    "prettier": "^1.5.2"
+    "prettier": "^1.12.1"
   }
 }


### PR DESCRIPTION
Per #2 : make installation easier by adding a one line installation that can be copied.

Per PR #3 : Update `eslint-config-prettier` version and add support for `eslint-plugin-standard` exclusions.

Per #4 : Update `eslint-config-standard` version 

Misc : Update `eslint-plugin-prettier` version and dev dependency versions.