### PR TITLE
Release 4.0.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ These instructions assume that you've already installed ESLint
 ### Two Line Installation
 
 ```
-npm install --save-dev eslint-config-prettier eslint-config-prettier-standard eslint-config-standard eslint-plugin-import eslint-plugin-node eslint-plugin-prettier eslint-plugin-promise eslint-plugin-standard prettier-config-standard
+npm install --save-dev eslint-config-prettier eslint-config-prettier-standard eslint-config-standard eslint-plugin-import eslint-plugin-node eslint-plugin-prettier eslint-plugin-promise prettier-config-standard
 npm install --save-dev --save-exact prettier
 ```
 
@@ -21,7 +21,7 @@ npm install --save-dev --save-exact prettier
 Install the peer dependencies:
 
 ```
-npm install --save-dev eslint-config-standard eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node
+npm install --save-dev eslint-config-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node
 npm install --save-dev eslint-plugin-prettier eslint-config-prettier prettier-config-standard
 npm install --save-dev --save-exact prettier
 ```
@@ -48,7 +48,6 @@ Some of which have their own peer dependencies.
 | **eslint-plugin-import**    | • eslint-config-standard |
 | **eslint-plugin-node**      | • eslint-config-standard |
 | **eslint-plugin-promise**   | • eslint-config-standard |
-| **eslint-plugin-standard**  | • eslint-config-standard |
 | **prettier**                | • eslint-plugin-prettier |
 
 </details>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-prettier-standard",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "An ESLint shareable config for projects using 'Prettier' and 'JavaScript Standard Style' as ESLint rules.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-promise": "^4.1.1",
-    "eslint-plugin-standard": "^4.0.0",
     "prettier": "1.18.2",
     "prettier-config-standard": "^1.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "eslint-config-prettier": ">=5.0.0",
-    "eslint-config-standard": ">=12.0.0 - <16.0.0",
+    "eslint-config-standard": ">=16.0.0",
     "eslint-plugin-prettier": ">=3.1.0",
     "prettier-config-standard": ">=1.0.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^5.0.0",
-    "eslint-config-standard": "^12.0.0",
+    "eslint-config-standard": "^16.0.0",
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-prettier": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "prettier-config-standard": ">=1.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^7.12.1",
     "eslint-config-prettier": "^5.0.0",
     "eslint-config-standard": "^16.0.0",
-    "eslint-plugin-import": "^2.17.3",
-    "eslint-plugin-node": "^9.1.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.0",
-    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-promise": "^4.2.1",
     "prettier": "1.18.2",
     "prettier-config-standard": "^1.0.1"
   }


### PR DESCRIPTION
-   Updates **eslint-config-standard** peer dependency and dev dependency versions (#11)
-   Removes mentions of **eslint-plugin-standard** from README (#11)