### PR TITLE
Release 4.0.1

### DIFF
--- a/end.js
+++ b/end.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['prettier', 'prettier/standard']
+  extends: ['prettier']
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-prettier-standard",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "An ESLint shareable config for projects using 'Prettier' and 'JavaScript Standard Style' as ESLint rules.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
-   remove reference to deprecated/removed `prettier/standard` (#13)